### PR TITLE
refactor: rename project-level `plan.md` to `tracks.md`

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,3 +1,3 @@
 # Conductor Context
 
-If a user mentions a "plan" or asks about the plan, and they have used the conductor extension in the current session, they are likely referring to the `conductor/plan.md` file.
+If a user mentions a "plan" or asks about the plan, and they have used the conductor extension in the current session, they are likely referring to the `conductor/tracks.md` file or one of the track plans (`conductor/tracks/<track_id>/plan.md`).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When you run `/conductor:setup`, Conductor helps you define the core components 
 - `conductor/tech-stack.md`
 - `conductor/workflow.md`
 - `conductor/code_styleguides/`
-- `conductor/plan.md`
+- `conductor/tracks.md`
 
 ```bash
 /conductor:setup
@@ -77,7 +77,7 @@ When you’re ready to take on a new feature or bug fix, run `/conductor:newTrac
 Once you approve the plan, run `/conductor:implement`. Your coding agent then works through the `plan.md` file, checking off tasks as it completes them.
 
 **Updated Artifacts:**
-- `conductor/plan.md` (Status updates)
+- `conductor/tracks.md` (Status updates)
 - `conductor/tracks/<track_id>/plan.md` (Status updates)
 - Project context files (Synchronized on completion)
 
@@ -106,10 +106,10 @@ During implementation, you can also:
 
 | Command | Description | Artifacts |
 | :--- | :--- | :--- |
-| `/conductor:setup` | Scaffolds the project and sets up the Conductor environment. Run this once per project. | `conductor/product.md`<br>`conductor/tech-stack.md`<br>`conductor/workflow.md`<br>`conductor/plan.md` |
-| `/conductor:newTrack` | Starts a new feature or bug track. Generates `spec.md` and `plan.md`. | `conductor/tracks/<id>/spec.md`<br>`conductor/tracks/<id>/plan.md`<br>`conductor/plan.md` |
-| `/conductor:implement` | Executes the tasks defined in the current track's plan. | `conductor/plan.md`<br>`conductor/tracks/<id>/plan.md` |
-| `/conductor:status` | Displays the current progress of the main plan and active tracks. | Reads `conductor/plan.md` |
+| `/conductor:setup` | Scaffolds the project and sets up the Conductor environment. Run this once per project. | `conductor/product.md`<br>`conductor/tech-stack.md`<br>`conductor/workflow.md`<br>`conductor/tracks.md` |
+| `/conductor:newTrack` | Starts a new feature or bug track. Generates `spec.md` and `plan.md`. | `conductor/tracks/<id>/spec.md`<br>`conductor/tracks/<id>/plan.md`<br>`conductor/tracks.md` |
+| `/conductor:implement` | Executes the tasks defined in the current track's plan. | `conductor/tracks.md`<br>`conductor/tracks/<id>/plan.md` |
+| `/conductor:status` | Displays the current progress of the tracks file and active tracks. | Reads `conductor/tracks.md` |
 | `/conductor:revert` | Reverts a track, phase, or task by analyzing git history. | Reverts git history |
 
 ## Resources

--- a/commands/conductor/implement.toml
+++ b/commands/conductor/implement.toml
@@ -27,8 +27,8 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 
 1.  **Check for User Input:** First, check if the user provided a track name as an argument (e.g., `/conductor:implement <track_description>`).
 
-2.  **Parse Main Plan:** Read and parse the main plan file at `conductor/plan.md`. You must parse the file by splitting its content by the `---` separator to identify each track section. For each section, extract the status (`[ ]`, `[~]`, `[x]`), the track description (from the `##` heading), and the link to the track folder.
-    -   **CRITICAL:** If no track sections are found after parsing, announce: "The main plan is empty or malformed. No tracks to implement." and halt.
+2.  **Parse Tracks File:** Read and parse the tracks file at `conductor/tracks.md`. You must parse the file by splitting its content by the `---` separator to identify each track section. For each section, extract the status (`[ ]`, `[~]`, `[x]`), the track description (from the `##` heading), and the link to the track folder.
+    -   **CRITICAL:** If no track sections are found after parsing, announce: "The tracks file is empty or malformed. No tracks to implement." and halt.
 
 3.  **Continue:** Immediately proceed to the next step to select a track.
 
@@ -38,12 +38,12 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
         2.  If a unique match is found, confirm the selection with the user: "I found track '<track_description>'. Is this correct?"
         3.  If no match is found, or if the match is ambiguous, inform the user and ask for clarification. Suggest the next avaliable track as below.
     -   **If no track name was provided (or if the previous step failed):**
-        1.  **Identify Next Track:** Find the first track in the parsed main plan that is NOT marked as `[x] Completed`.
+        1.  **Identify Next Track:** Find the first track in the parsed tracks file that is NOT marked as `[x] Completed`.
         2.  **If a next track is found:**
             -   Announce: "No track name provided. Automatically selecting the next incomplete track: '<track_description>'."
             -   Proceed with this track.
         3.  **If no incomplete tracks are found:**
-            -   Announce: "No incomplete tracks found in the main plan. All tasks are completed!"
+            -   Announce: "No incomplete tracks found in the tracks file. All tasks are completed!"
             -   Halt the process and await further user instructions.
 
 5.  **Handle No Selection:** If no track is selected, inform the user and await further instructions.
@@ -56,11 +56,11 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 1.  **Announce Action:** Announce which track you are beginning to implement.
 
 2.  **Update Status to 'In Progress':**
-    -   Before beginning any work, you MUST update the status of the selected track in the `conductor/plan.md` file.
+    -   Before beginning any work, you MUST update the status of the selected track in the `conductor/tracks.md` file.
     -   This requires finding the specific heading for the track (e.g., `## [ ] Track: <Description>`) and replacing it with the updated status (e.g., `## [~] Track: <Description>`).
 
 3.  **Load Track Context:**
-    a. **Identify Track Folder:** From the main plan, identify the track's folder link to get the `<track_id>`.
+    a. **Identify Track Folder:** From the tracks file, identify the track's folder link to get the `<track_id>`.
     b. **Read Files:** You MUST read the content of the following files into your context using their full, absolute paths:
         - `conductor/tracks/<track_id>/plan.md`
         - `conductor/tracks/<track_id>/spec.md`
@@ -74,16 +74,16 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
         i. **Defer to Workflow:** The `workflow.md` file is the **single source of truth** for the entire task lifecycle. You MUST now read and execute the procedures defined in the "Task Workflow" section of the `workflow.md` file you have in your context. Follow its steps for implementation, testing, and committing precisely.
 
 5.  **Finalize Track:**
-    -   After all tasks in the track's local `plan.md` are completed, you MUST update the track's status in the main plan file.
+    -   After all tasks in the track's local `plan.md` are completed, you MUST update the track's status in the tracks file.
     -   This requires finding the specific heading for the track (e.g., `## [~] Track: <Description>`) and replacing it with the completed status (e.g., `## [x] Track: <Description>`).
-    -   Announce that the track is fully complete and the main plan has been updated.
+    -   Announce that the track is fully complete and the tracks file has been updated.
 
 ---
 
 ## 6.0 SYNCHRONIZE PROJECT DOCUMENTATION
 **PROTOCOL: Update project-level documentation based on the completed track.**
 
-1.  **Execution Trigger:** This protocol MUST only be executed when a track has reached a `[x]` status in the main plan. DO NOT execute this protocol for any other track status changes.
+1.  **Execution Trigger:** This protocol MUST only be executed when a track has reached a `[x]` status in the tracks file. DO NOT execute this protocol for any other track status changes.
 
 2.  **Announce Synchronization:** Announce that you are now synchronizing the project-level documentation with the completed track's specifications.
 
@@ -144,16 +144,16 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 
 2.  **Ask for User Choice:** You MUST prompt the user with the available options for the completed track.
     > "Track '<track_description>' is now complete. What would you like to do?
-    > A.  **Archive:** Move the track's folder to `conductor/archive/` and remove it from the main plan.
-    > B.  **Delete:** Permanently delete the track's folder and remove it from the main plan.
-    > C.  **Skip:** Do nothing and leave it in the main plan.
+    > A.  **Archive:** Move the track's folder to `conductor/archive/` and remove it from the tracks file.
+    > B.  **Delete:** Permanently delete the track's folder and remove it from the tracks file.
+    > C.  **Skip:** Do nothing and leave it in the tracks file.
     > Please enter the number of your choice (A, B, or C)."
 
 3.  **Handle User Response:**
     *   **If user chooses "A" (Archive):**
         i.   **Create Archive Directory:** Check for the existence of `conductor/archive/`. If it does not exist, create it.
         ii.  **Archive Track Folder:** Move the track's folder from `conductor/tracks/<track_id>` to `conductor/archive/<track_id>`.
-        iii. **Remove from Main Plan:** Read the content of `conductor/plan.md`, remove the entire section for the completed track (the part that starts with `---` and contains the track description), and write the modified content back to the file.
+        iii. **Remove from Tracks File:** Read the content of `conductor/tracks.md`, remove the entire section for the completed track (the part that starts with `---` and contains the track description), and write the modified content back to the file.
         iv.  **Announce Success:** Announce: "Track '<track_description>' has been successfully archived."
     *   **If user chooses "B" (Delete):**
         i. **CRITICAL WARNING:** Before proceeding, you MUST ask for a final confirmation due to the irreversible nature of the action.
@@ -161,10 +161,10 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
         ii. **Handle Confirmation:**
             - **If 'yes'**:
                 a. **Delete Track Folder:** Permanently delete the track's folder from `conductor/tracks/<track_id>`.
-                b. **Remove from Main Plan:** Read the content of `conductor/plan.md`, remove the entire section for the completed track, and write the modified content back to the file.
+                b. **Remove from Tracks File:** Read the content of `conductor/tracks.md`, remove the entire section for the completed track, and write the modified content back to the file.
                 c. **Announce Success:** Announce: "Track '<track_description>' has been permanently deleted."
             - **If 'no' (or anything else)**:
                 a. **Announce Cancellation:** Announce: "Deletion cancelled. The track has not been changed."
     *   **If user chooses "C" (Skip) or provides any other input:**
-        *   Announce: "Okay, the completed track will remain in your main plan for now."
+        *   Announce: "Okay, the completed track will remain in your tracks file for now."
 """

--- a/commands/conductor/newTrack.toml
+++ b/commands/conductor/newTrack.toml
@@ -1,4 +1,4 @@
-description = "Plans a track, generates track-specific spec documents and updates the main plan"
+description = "Plans a track, generates track-specific spec documents and updates the tracks file"
 prompt = """
 ## 1.0 SYSTEM DIRECTIVE
 You are an AI agent assistant for the Conductor spec-driven development framework. Your current task is to guide the user through the creation of a new "Track" (a feature or bug fix), generate the necessary specification (`spec.md`) and plan (`plan.md`) files, and organize them within a dedicated track directory.
@@ -125,9 +125,9 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 5.  **Write Files:**
     *   Write the confirmed specification content to `conductor/tracks/<track_id>/spec.md`.
     *   Write the confirmed plan content to `conductor/tracks/<track_id>/plan.md`.
-6.  **Update Main Plan:**
-    -   **Announce:** Inform the user you are updating the main plan.
-    -   **Append Section:** Append a new section for the track to the end of `conductor/plan.md`. The format MUST be:
+6.  **Update Tracks File:**
+    -   **Announce:** Inform the user you are updating the tracks file.
+    -   **Append Section:** Append a new section for the track to the end of `conductor/tracks.md`. The format MUST be:
         ```markdown
 
         ---
@@ -137,6 +137,6 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
         ```
         (Replace placeholders with actual values)
 7.  **Announce Completion:** Inform the user:
-    > "New track '<track_id>' has been created and added to the main plan. You can now start implementation by running `/conductor:implement`."
+    > "New track '<track_id>' has been created and added to the tracks file. You can now start implementation by running `/conductor:implement`."
 
 """

--- a/commands/conductor/revert.toml
+++ b/commands/conductor/revert.toml
@@ -10,8 +10,8 @@ Your workflow MUST anticipate and handle common non-linear Git histories, such a
 **CRITICAL**: The user's explicit confirmation is required at multiple checkpoints. If a user denies a confirmation, the process MUST halt immediately and follow further instructions. 
 
 **CRITICAL:** Before proceeding, you should start by checking if the project has been properly set up.
-1.  **Verify Main Plan:** Check if the file `conductor/plan.md` exists. If it does not, HALT execution and instruct the user: "The project has not been set up or conductor/plan.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/plan.md."
-2.  **Verify Track Exists:** Check if the file `conductor/plan.md` is not empty. If it is empty, HALT execution and instruct the user: "The project has not been set up or conductor/plan.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/plan.md." 
+1.  **Verify Tracks File:** Check if the file `conductor/tracks.md` exists. If it does not, HALT execution and instruct the user: "The project has not been set up or conductor/tracks.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/tracks.md."
+2.  **Verify Track Exists:** Check if the file `conductor/tracks.md` is not empty. If it is empty, HALT execution and instruct the user: "The project has not been set up or conductor/tracks.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/tracks.md." 
 
 **CRITICAL**: You must validate the success of every tool call. If any tool call fails, you MUST halt the current operation immediately, announce the failure to the user, and await further instructions.
 
@@ -29,7 +29,7 @@ Your workflow MUST anticipate and handle common non-linear Git histories, such a
 3.  **Interaction Paths:**
 
     *   **PATH A: Direct Confirmation**
-        1.  Find the specific track, phase, or task the user referenced in the project's `plan.md` files.
+        1.  Find the specific track, phase, or task the user referenced in the project's `tracks.md` or `plan.md` files.
         2.  Ask the user for confirmation: "You asked to revert the [Track/Phase/Task]: '[Description]'. Is this correct?".
             - **Structure:**
                 A) Yes
@@ -38,7 +38,7 @@ Your workflow MUST anticipate and handle common non-linear Git histories, such a
 
     *   **PATH B: Guided Selection Menu**
         1.  **Identify Revert Candidates:** Your primary goal is to find relevant items for the user to revert.
-            *   **Scan All Plans:** You MUST read the main `conductor/plan.md` and every `conductor/tracks/*/plan.md` file.
+            *   **Scan All Plans:** You MUST read the main `conductor/tracks.md` and every `conductor/tracks/*/plan.md` file.
             *   **Prioritize In-Progress:** First, find **all** Tracks, Phases, and Tasks marked as "in-progress" (`[~]`).
             *   **Fallback to Completed:** If and only if NO in-progress items are found, find the **5 most recently completed** Tasks and Phases (`[x]`).
         2.  **Present a Unified Hierarchical Menu:** You MUST present the results to the user in a clear, numbered, hierarchical list grouped by Track. The introductory text MUST change based on the context.
@@ -84,7 +84,7 @@ Your workflow MUST anticipate and handle common non-linear Git histories, such a
 
 3.  **Identify the Track Creation Commit (Track Revert Only):**
     *   **IF** the user's intent is to revert an entire track, you MUST perform this additional step.
-    *   **Method:** Use `git log -- conductor/plan.md` and search for the commit that first introduced the `## [ ] Track: <Track Description>` line for the target track into the main plan.
+    *   **Method:** Use `git log -- conductor/tracks.md` and search for the commit that first introduced the `## [ ] Track: <Track Description>` line for the target track into the tracks file.
     *   Add this "track creation" commit's SHA to the list of commits to be reverted.
 
 4.  **Compile and Analyze Final List:**

--- a/commands/conductor/setup.toml
+++ b/commands/conductor/setup.toml
@@ -372,11 +372,11 @@ CRITICAL: When determining model complexity, ALWAYS select the "flash" model, re
 
 ### 3.3 Convert the Initial Track into Artifacts (Automated)
 1.  **State Your Goal:** Once the track is approved, announce that you will now create the artifacts for this initial track.
-2.  **Initialize Main Plan:** Create the `conductor/plan.md` file with the initial header and the first track:
+2.  **Initialize Tracks File:** Create the `conductor/tracks.md` file with the initial header and the first track:
     ```markdown
-    # Main Project Plan
+    # Project Tracks
 
-    This plan tracks all major tracks for the project. Each track has its own detailed plan in its respective folder.
+    This file tracks all major tracks for the project. Each track has its own detailed plan in its respective folder.
 
     ---
 

--- a/commands/conductor/status.toml
+++ b/commands/conductor/status.toml
@@ -1,11 +1,11 @@
 description = "Displays the current progress of the project"
 prompt = """
 ## 1.0 SYSTEM DIRECTIVE
-You are an AI agent. Your primary function is to provide a status overview of the current project plan. This involves reading the `conductor/plan.md` file, parsing its content, and summarizing the progress of tasks.
+You are an AI agent. Your primary function is to provide a status overview of the current tracks file. This involves reading the `conductor/tracks.md` file, parsing its content, and summarizing the progress of tasks.
 
 **CRITICAL:** Before proceeding, you should start by checking if the project has been properly set up.
-1.  **Verify Main Plan:** Check if the file `conductor/plan.md` exists. If it does not, HALT execution and instruct the user: "The project has not been set up or conductor/plan.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/plan.md."
-2.  **Verify Track Exists:** Check if the file `conductor/plan.md` is not empty. If it is empty, HALT execution and instruct the user: "The project has not been set up or conductor/plan.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/plan.md." 
+1.  **Verify Tracks File:** Check if the file `conductor/tracks.md` exists. If it does not, HALT execution and instruct the user: "The project has not been set up or conductor/tracks.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/tracks.md."
+2.  **Verify Track Exists:** Check if the file `conductor/tracks.md` is not empty. If it is empty, HALT execution and instruct the user: "The project has not been set up or conductor/tracks.md has been corrupted. Please run `/conductor:setup` to set up the plan, or restore conductor/tracks.md." 
 
 CRITICAL: You must validate the success of every tool call. If any tool call fails, you MUST halt the current operation immediately, announce the failure to the user, and await further instructions.
 
@@ -31,7 +31,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 **PROTOCOL: Follow this sequence to provide a status overview.**
 
 ### 2.1 Read Project Plan
-1.  **Locate and Read:** Read the content of the `conductor/plan.md` file.
+1.  **Locate and Read:** Read the content of the `conductor/tracks.md` file.
 2.  **Locate and Read:** List the tracks using shell command `ls conductor/tracks`. For each of the tracks, read the corresponding `conductor/<track_id>/plan.md` file. 
 
 ### 2.2 Parse and Summarize Plan


### PR DESCRIPTION
Renamed project-level `plan.md` to `tracks.md` and updated references in documentation and command configurations.