### PR TITLE
feat(styleguide): Add comprehensive Google C# Style Guide summary

### DIFF
--- a/templates/code_styleguides/csharp.md
+++ b/templates/code_styleguides/csharp.md
@@ -11,7 +11,6 @@ This document summarizes key rules and best practices from the Google C# Style G
   - Example: `localVariable`, `methodParameter`
 - **Interfaces:** Prefix with `I` (e.g., `IMyInterface`).
 - **Type Parameters:** Use descriptive names prefixed with `T` (e.g., `TValue`, `TKey`), or just `T` for simple cases.
-- **Async Methods:** Suffix with `Async` (e.g., `GetDataAsync()`).
 
 ## 2. Formatting Rules
 - **Indentation:** Use 2 spaces (never tabs).
@@ -73,18 +72,31 @@ Class member ordering:
   ```
 
 ## 5. Best Practices
+- **Structs vs Classes**:
+  - Almost always use a class.
+  - Consider structs only for small, value-like types that are short-lived or frequently embedded.
+  - Performance considerations may justify deviations from this guidance.
 - **Access Modifiers:** Always explicitly declare access modifiers (don't rely on defaults).
 - **Ordering Modifiers:** Use standard order: `public protected internal private new abstract virtual override sealed static readonly extern unsafe volatile async`.
 - **Namespace Imports:** Place `using` directives at the top of the file (outside namespaces); `System` first, then alphabetical.
 - **Constants:** Always make variables `const` when possible; if not, use `readonly`. Prefer named constants over magic numbers.
+- **IEnumerable vs IList vs IReadOnlyList:** When method inputs are intended to be immutable, prefer the most restrictive collection type possible (e.g., IEnumerable, IReadOnlyList); for return values, prefer IList when transferring ownership of a mutable collection, and otherwise prefer the most restrictive option.
 - **Array vs List:** Prefer `List<>` for public variables, properties, and return types. Use arrays when size is fixed and known at construction time, or for multidimensional arrays.
 - **Extension Methods:** Only use when the source is unavailable or changing it is infeasible. Only for core, general features. Be aware they obfuscate code.
 - **LINQ:** Use LINQ for readability, but be mindful of performance in hot paths.
 
 ## 6. File Organization
 - **One Class Per File:** Typically one class, interface, enum, or struct per file.
-- **File Name:** Should match the name of the primary type in the file.
-- **Namespace:** Should follow folder structure.
+- **File Name:** Prefer the file name to match the name of the primary type it contains.
+- **Folders and File Locations:**
+  - Be consistent within the project.
+  - Prefer a flat folder structure where possible.
+  - Don’t force file/folder layout to match namespaces.
+- **Namespaces:**
+  - In general, namespaces should be no more than 2 levels deep.
+  - For shared library/module code, use namespaces.
+  - For leaf application code, namespaces are not necessary.
+  - New top-level namespace names must be globally unique and recognizable.
 
 ## 7. Parameters and Returns
 - **out Parameters:** Permitted for output-only values; place `out` parameters after all other parameters. Prefer tuples or return types when they improve clarity.


### PR DESCRIPTION
This pull request adds a new summary document for the Google C# Style Guide. The document provides concise guidance on naming conventions, formatting, declaration order, language features, best practices, comments and documentation, file organization, disallowed features, and modern C# features.

New documentation:

* Added `templates/code_styleguides/csharp.md` containing a summary of the Google C# Style Guide, including naming conventions, formatting rules, declaration order, recommended language features, and best practices.
* Included guidance on file organization, disallowed features, and usage of modern C# features such as nullable reference types, records, and switch expressions.
* Referenced the official Google C# Style Guide as the source for these recommendations.