### PR TITLE
fix: Correct typos, step numbering, and documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ During implementation, you can also:
 
 | Command | Description | Artifacts |
 | :--- | :--- | :--- |
-| `/conductor:setup` | Scaffolds the project and sets up the Conductor environment. Run this once per project. | `conductor/product.md`<br>`conductor/tech-stack.md`<br>`conductor/workflow.md`<br>`conductor/tracks.md` |
+| `/conductor:setup` | Scaffolds the project and sets up the Conductor environment. Run this once per project. | `conductor/product.md`<br>`conductor/product-guidelines.md`<br>`conductor/tech-stack.md`<br>`conductor/workflow.md`<br>`conductor/tracks.md` |
 | `/conductor:newTrack` | Starts a new feature or bug track. Generates `spec.md` and `plan.md`. | `conductor/tracks/<id>/spec.md`<br>`conductor/tracks/<id>/plan.md`<br>`conductor/tracks.md` |
 | `/conductor:implement` | Executes the tasks defined in the current track's plan. | `conductor/tracks.md`<br>`conductor/tracks/<id>/plan.md` |
 | `/conductor:status` | Displays the current progress of the tracks file and active tracks. | Reads `conductor/tracks.md` |

--- a/commands/conductor/newTrack.toml
+++ b/commands/conductor/newTrack.toml
@@ -118,7 +118,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
       "status": "new", // or in_progress, completed, cancelled
       "created_at": "YYYY-MM-DDTHH:MM:SSZ",
       "updated_at": "YYYY-MM-DDTHH:MM:SSZ",
-      "description": "<Initial user description>",
+      "description": "<Initial user description>"
     }
     ```
     *   Populate fields with actual values. Use the current timestamp.

--- a/commands/conductor/setup.toml
+++ b/commands/conductor/setup.toml
@@ -406,7 +406,7 @@ CRITICAL: When determining model complexity, ALWAYS select the "flash" model, re
             "status": "new", // or in_progress, completed, cancelled
             "created_at": "YYYY-MM-DDTHH:MM:SSZ",
             "updated_at": "YYYY-MM-DDTHH:MM:SSZ",
-            "description": "<Initial user description>",
+            "description": "<Initial user description>"
             }
             ```
         Populate fields with actual values. Use the current timestamp.

--- a/commands/conductor/status.toml
+++ b/commands/conductor/status.toml
@@ -32,7 +32,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 
 ### 2.1 Read Project Plan
 1.  **Locate and Read:** Read the content of the `conductor/tracks.md` file.
-2.  **Locate and Read:** List the tracks using shell command `ls conductor/tracks`. For each of the tracks, read the corresponding `conductor/<track_id>/plan.md` file.
+2.  **Locate and Read:** List the tracks using shell command `ls conductor/tracks`. For each of the tracks, read the corresponding `conductor/tracks/<track_id>/plan.md` file.
 
 ### 2.2 Parse and Summarize Plan
 1.  **Parse Content:**

--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -120,13 +120,13 @@ All tasks follow a strict lifecycle:
     -   Perform the commit with a clear and concise message (e.g., `conductor(checkpoint): Checkpoint end of Phase X`).
 
 7.  **Attach Auditable Verification Report using Git Notes:**
-    -   **Step 8.1: Draft Note Content:** Create a detailed verification report including the automated test command, the manual verification steps, and the user's confirmation.
-    -   **Step 8.2: Attach Note:** Use the `git notes` command and the full commit hash from the previous step to attach the full report to the checkpoint commit.
+    -   **Step 7.1: Draft Note Content:** Create a detailed verification report including the automated test command, the manual verification steps, and the user's confirmation.
+    -   **Step 7.2: Attach Note:** Use the `git notes` command and the full commit hash from the previous step to attach the full report to the checkpoint commit.
 
 8.  **Get and Record Phase Checkpoint SHA:**
-    -   **Step 7.1: Get Commit Hash:** Obtain the hash of the *just-created checkpoint commit* (`git log -1 --format="%H"`).
-    -   **Step 7.2: Update Plan:** Read `plan.md`, find the heading for the completed phase, and append the first 7 characters of the commit hash in the format `[checkpoint: <sha>]`.
-    -   **Step 7.3: Write Plan:** Write the updated content back to `plan.md`.
+    -   **Step 8.1: Get Commit Hash:** Obtain the hash of the *just-created checkpoint commit* (`git log -1 --format="%H"`).
+    -   **Step 8.2: Update Plan:** Read `plan.md`, find the heading for the completed phase, and append the first 7 characters of the commit hash in the format `[checkpoint: <sha>]`.
+    -   **Step 8.3: Write Plan:** Write the updated content back to `plan.md`.
 
 9. **Commit Plan Update:**
     - **Action:** Stage the modified `plan.md` file.


### PR DESCRIPTION
## Summary
This PR fixes several typos and documentation inconsistencies:

- **status.toml**: Fixed incorrect path reference (`conductor/<track_id>` → `conductor/tracks/<track_id>`)
- **workflow.md**: Fixed step numbering errors (Steps 7 and 8 had swapped sub-step numbers)
- **newTrack.toml & setup.toml**: Removed trailing commas from JSON examples
- **README.md**: Added missing `product-guidelines.md` to the Commands Reference table

## Testing
These are documentation/prompt fixes that don't require runtime testing.