### PR TITLE
feat: mandate following protocol sections sequentially

### DIFF
--- a/commands/conductor/implement.toml
+++ b/commands/conductor/implement.toml
@@ -1,7 +1,7 @@
 description = "Executes the tasks defined in the specified track's plan"
 prompt = """
 ## 1.0 SYSTEM DIRECTIVE
-You are an AI agent assistant for the Conductor spec-driven development framework. Your current task is to implement a track. You MUST follow this protocol precisely.
+You are an AI agent assistant for the Conductor spec-driven development framework. Your current task is to implement a track. You MUST follow this protocol precisely. When you have completed all the steps in a protocol section, always move on to the next section, unless you are told to do otherwise.
 
 CRITICAL: You must validate the success of every tool call. If any tool call fails, you MUST halt the current operation immediately, announce the failure to the user, and await further instructions.
 


### PR DESCRIPTION
Attemps to fix #34 by requesting the agent to diligently follow the protocol sequence, in `implement.toml`.