### PR TITLE
fix(conductor): ensure track completion and doc sync are committed automatically

### DIFF
--- a/commands/conductor/implement.toml
+++ b/commands/conductor/implement.toml
@@ -76,7 +76,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 5.  **Finalize Track:**
     -   After all tasks in the track's local `plan.md` are completed, you MUST update the track's status in the tracks file.
     -   This requires finding the specific heading for the track (e.g., `## [~] Track: <Description>`) and replacing it with the completed status (e.g., `## [x] Track: <Description>`).
-    -   **Commit Changes:** Stage `conductor/tracks.md` and commit with the message `conductor(track): Mark track '<track_description>' as complete`.
+    -   **Commit Changes:** Stage `conductor/tracks.md` and commit with the message `chore(conductor): Mark track '<track_description>' as complete`.
     -   Announce that the track is fully complete and the tracks file has been updated.
 
 ---
@@ -130,7 +130,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
     - **Construct the Message:** Based on the records of which files were changed, construct a summary message.
     - **Commit Changes:**
         - If any files were changed (`product.md`, `tech-stack.md`, or `product-guidelines.md`), you MUST stage them and commit them.
-        - **Commit Message:** `conductor(docs): Synchronize docs for track '<track_description>'`
+        - **Commit Message:** `docs(conductor): Synchronize docs for track '<track_description>'`
     - **Example (if product.md was changed, but others were not):**
         > "Documentation synchronization is complete.
         > - **Changes made to `product.md`:** The user-facing description of the product was updated to include the new feature.
@@ -158,7 +158,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
         i.   **Create Archive Directory:** Check for the existence of `conductor/archive/`. If it does not exist, create it.
         ii.  **Archive Track Folder:** Move the track's folder from `conductor/tracks/<track_id>` to `conductor/archive/<track_id>`.
         iii. **Remove from Tracks File:** Read the content of `conductor/tracks.md`, remove the entire section for the completed track (the part that starts with `---` and contains the track description), and write the modified content back to the file.
-        iv.  **Commit Changes:** Stage `conductor/tracks.md` and `conductor/archive/`. Commit with the message `conductor(track): Archive track '<track_description>'`.
+        iv.  **Commit Changes:** Stage `conductor/tracks.md` and `conductor/archive/`. Commit with the message `chore(conductor): Archive track '<track_description>'`.
         v.   **Announce Success:** Announce: "Track '<track_description>' has been successfully archived."
     *   **If user chooses "B" (Delete):**
         i. **CRITICAL WARNING:** Before proceeding, you MUST ask for a final confirmation due to the irreversible nature of the action.
@@ -167,7 +167,7 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
             - **If 'yes'**:
                 a. **Delete Track Folder:** Permanently delete the track's folder from `conductor/tracks/<track_id>`.
                 b. **Remove from Tracks File:** Read the content of `conductor/tracks.md`, remove the entire section for the completed track, and write the modified content back to the file.
-                c. **Commit Changes:** Stage `conductor/tracks.md` and the deletion of `conductor/tracks/<track_id>`. Commit with the message `conductor(track): Delete track '<track_description>'`.
+                c. **Commit Changes:** Stage `conductor/tracks.md` and the deletion of `conductor/tracks/<track_id>`. Commit with the message `chore(conductor): Delete track '<track_description>'`.
                 d. **Announce Success:** Announce: "Track '<track_description>' has been permanently deleted."
             - **If 'no' (or anything else)**:
                 a. **Announce Cancellation:** Announce: "Deletion cancelled. The track has not been changed."


### PR DESCRIPTION
This adds explicit commit steps to the implement command for:
- Track completion status updates in tracks.md
- Project documentation synchronization
- Track cleanup (archiving or deleting)

Fixes #16
Testing: [test_scenarios.md](https://github.com/user-attachments/files/24413177/test_scenarios.md)