### PR TITLE
chore(github-actions): use dedicated bot token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ jobs:
         id: release
         with:
           target-branch: ${{ github.ref_name }}
+          token: ${{ secrets.BOT_RELEASE_TOKEN }}
 
       - name: Checkout code
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Switches the release workflow to use a dedicated bot account token (`BOT_RELEASE_TOKEN`) instead of the default `GITHUB_TOKEN` to ensure subsequent workflows (like release-related CI) are triggered correctly.

This is necessary because the default `github-actions` bot is not allowlisted for the Google CLA, and using a dedicated bot account (https://github.com/google-conductor-bot) allows us to bypass this limitation.