### PR TITLE
docs: introduced C++ google style guide summary

### DIFF
--- a/templates/code_styleguides/cpp.md
+++ b/templates/code_styleguides/cpp.md
@@ -96,7 +96,7 @@
 - **RTTI:** Avoid `dynamic_cast`/`typeid`. Allowed in unit tests. Do not hand-implement workarounds.
 - **Macros:** Avoid. Use `constexpr`/`inline`. If needed, define close to use and `#undef` immediately. Do not define in headers.
 - **0 and nullptr:** Use `nullptr` for pointers, `\0` for chars, not `0`.
-- **Streams:** Prefer `std::cout`/`std::cerr` over `printf`. Avoid stateful streams.
+- **Streams:** Use streams primarily for logging. Prefer printf-style formatting or absl::StrCat.
 - **Types:** Avoid `unsigned` for non-negativity. No `long double`.
 - **Pre-increment:** Prefer `++i` over `i++`.
 - **Sizeof:** Prefer `sizeof(varname)` over `sizeof(type)`.


### PR DESCRIPTION
Description
- Adds a concise reference guide for Google's C++ style conventions, following the established format of existing code style guides in the repository.

Changes
- New file summarizing the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html)
- Covers 8 key areas: Naming, Header Files, Formatting, Classes, Functions, Scoping, Modern C++ Features, and Best Practices

Approach
- Distilled the full guide into actionable, quick-reference rules
- Maintained consistency with other style guide summaries in this repo
- Prioritized the most commonly referenced conventions while preserving important exceptions and edge cases