### PR TITLE
fix(setup): announce state check to user before execution

### DIFF
--- a/commands/conductor/setup.toml
+++ b/commands/conductor/setup.toml
@@ -12,11 +12,13 @@ CRITICAL: When determining model complexity, ALWAYS select the "flash" model, re
 ## 1.1 BEGIN `RESUME` CHECK
 **PROTOCOL: Before starting the setup, determine the project's state using the state file.**
 
-1.  **Read State File:** Check for the existence of `conductor/setup_state.json`.
+1.  **Announce Check:** Inform the user that you are checking for an existing project state to resume from.
+
+2.  **Read State File:** Check for the existence of `conductor/setup_state.json`.
     - If it does not exist, this is a new project setup. Proceed directly to Step 1.2.
     - If it exists, read its content.
 
-2.  **Resume Based on State:**
+3.  **Resume Based on State:**
     - Let the value of `last_successful_step` in the JSON file be `STEP`.
     - Based on the value of `STEP`, jump to the **next logical section**:
 


### PR DESCRIPTION
Updates the system prompt to inform the user before checking for 'setup_state.json'. This prevents the jarring silence during startup.

Fixes #81