### PR TITLE
feat: add qwen-extension.json for Qwen Code compatibility

### DIFF
--- a/qwen-extension.json
+++ b/qwen-extension.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "0.0.1",
+  "name": "conductor",
+  "version": "0.1.0",
+  "description": "Specify, plan, and implement software features",
+  "repository": "https://github.com/gemini-cli-extensions/conductor",
+  "license": "Apache-2.0",
+  "commands": [
+    {
+      "name": "conductor",
+      "description": "Specify, plan, and implement software features",
+      "handler": "./dist/commands/conductor.js"
+    }
+  ],
+  "dependencies": []
+}


### PR DESCRIPTION
Adds `qwen-extension.json` to enable installation via Qwen Code CLI while maintaining full backward compatibility with Gemini CLI.

## Problem

When installing this extension using Qwen Code CLI:

```bash
qwen extensions install https://github.com/gemini-cli-extensions/conductor
```

The installation fails with:

```
Configuration file not found at ...\qwen-extension.json
```

This occurs because Qwen Code (a fork of Gemini CLI) expects `qwen-extension.json` as the extension manifest filename, whereas this repo only provides `gemini-extension.json`.

## Solution

Added `qwen-extension.json` with identical content to `gemini-extension.json`. This change:

✅ Enables installation via Qwen Code CLI  
✅ Maintains full backward compatibility with Gemini CLI (which continues to use `gemini-extension.json`)  
✅ Introduces zero breaking changes — purely additive

## Verification

✅ **Tested locally on Windows:**

```bash
qwen extensions install .
qwen extensions list
```

Output:
```
✓ conductor (0.1.0)
```

✅ **No impact on existing functionality** — Gemini CLI users remain unaffected and can continue using `gemini extensions install` as before.

## Compatibility Note

Qwen Code and Gemini CLI share nearly identical extension schemas and loading logic. This change simply adds the filename variant (`qwen-extension.json`) expected by Qwen Code's extension loader, without modifying any behavior or configuration structure.

---

Fixes: https://github.com/QwenLM/qwen-code/issues/1621