### PR TITLE
chore(conductor): Add post-execution advice to commands

### DIFF
--- a/commands/conductor/implement.toml
+++ b/commands/conductor/implement.toml
@@ -176,4 +176,12 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
                 a. **Announce Cancellation:** Announce: "Deletion cancelled. The track has not been changed."
     *   **If user chooses "D" (Skip) or provides any other input:**
         *   Announce: "Okay, the completed track will remain in your tracks file for now."
+
+---
+
+## 6.0 POST-EXECUTION ADVICE
+**CRITICAL:** You MUST display the following tip to the user ONLY when the entire command execution is finished and you are about to halt. DO NOT display this tip if you are asking for user input or if the command is still in progress.
+
+"**TIP:** Use `/clear` or `/compress` to reduce context window and latency."
+
 """

--- a/commands/conductor/newTrack.toml
+++ b/commands/conductor/newTrack.toml
@@ -151,4 +151,12 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 7.  **Announce Completion:** Inform the user:
     > "New track '<track_id>' has been created and added to the tracks file. You can now start implementation by running `/conductor:implement`."
 
+
+---
+
+## 3.0 POST-EXECUTION ADVICE
+**CRITICAL:** You MUST display the following tip to the user ONLY when the entire command execution is finished and you are about to halt. DO NOT display this tip if you are asking for user input or if the command is still in progress.
+
+"**TIP:** Use `/clear` or `/compress` to reduce context window and latency."
+
 """

--- a/commands/conductor/revert.toml
+++ b/commands/conductor/revert.toml
@@ -127,4 +127,12 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 2.  **Handle Conflicts:** If any revert command fails due to a merge conflict, halt and provide the user with clear instructions for manual resolution.
 3.  **Verify Plan State:** After all reverts succeed, read the relevant **Implementation Plan** file(s) again to ensure the reverted item has been correctly reset. If not, perform a file edit to fix it and commit the correction.
 4.  **Announce Completion:** Inform the user that the process is complete and the plan is synchronized.
+
+---
+
+## 6.0 POST-EXECUTION ADVICE
+**CRITICAL:** You MUST display the following tip to the user ONLY when the entire command execution is finished and you are about to halt. DO NOT display this tip if you are asking for user input or if the command is still in progress.
+
+"**TIP:** Use `/clear` or `/compress` to reduce context window and latency."
+
 """

--- a/commands/conductor/review.toml
+++ b/commands/conductor/review.toml
@@ -155,4 +155,12 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
             ii.  **If yes:** Delete track folder, remove from **Tracks Registry**, commit (`chore(conductor): Delete track '<track_name>'`), announce success.
             iii. **If no:** Cancel.
         *   **If "C" (Skip):** Leave track as is.
+
+---
+
+## 4.0 POST-EXECUTION ADVICE
+**CRITICAL:** You MUST display the following tip to the user ONLY when the entire command execution is finished and you are about to halt. DO NOT display this tip if you are asking for user input or if the command is still in progress.
+
+"**TIP:** Use `/clear` or `/compress` to reduce context window and latency."
+
 """

--- a/commands/conductor/setup.toml
+++ b/commands/conductor/setup.toml
@@ -453,4 +453,12 @@ CRITICAL: When determining model complexity, ALWAYS select the "flash" model, re
 1.  **Announce Completion:** After the track has been created, announce that the project setup and initial track generation are complete.
 2.  **Save Conductor Files:** Add and commit all files with the commit message `conductor(setup): Add conductor setup files`.
 3.  **Next Steps:** Inform the user that they can now begin work by running `/conductor:implement`.
+
+---
+
+## 4.0 POST-EXECUTION ADVICE
+**CRITICAL:** You MUST display the following tip to the user ONLY when the entire command execution is finished and you are about to halt. DO NOT display this tip if you are asking for user input or if the command is still in progress.
+
+"**TIP:** Use `/clear` or `/compress` to reduce context window and latency."
+
 """


### PR DESCRIPTION
Adds a post-execution tip to conductor commands reminding users to use /clear or /compress.