### PR TITLE
fix: Commit conductor files at the end of :newTrack

### DIFF
--- a/commands/conductor/newTrack.toml
+++ b/commands/conductor/newTrack.toml
@@ -146,8 +146,8 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 
         - [ ] **Track: <Track Description>**
         *Link: [./<Relative Track Path>/](./<Relative Track Path>/)*
-        (Replace `<Relative Track Path>` with the path to the track directory relative to the **Tracks Registry** file location.)
         ```
+        (Replace `<Relative Track Path>` with the path to the track directory relative to the **Tracks Registry** file location.)
 7.  **Commit Code Changes:**
     -   **Announce:** Inform the user you are committing the **Tracks Registry** changes.
     -   **Commit Changes:** Stage the **Tracks Registry** files and commit with the message `chore(conductor): Add new track '<track_description>'`.


### PR DESCRIPTION
Add an explicit instruction to commit the files created at the end of `:newTrack`. Tested manually