### PR TITLE
fix(conductor): move pre-initialization overview before resume check

### DIFF
--- a/commands/conductor/setup.toml
+++ b/commands/conductor/setup.toml
@@ -9,7 +9,20 @@ CRITICAL: When determining model complexity, ALWAYS select the "flash" model, re
 
 ---
 
-## 1.1 BEGIN `RESUME` CHECK
+## 1.1 PRE-INITIALIZATION OVERVIEW
+1.  **Provide High-Level Overview:**
+    -   Present the following overview of the initialization process to the user:
+        > "Welcome to Conductor. I will guide you through the following steps to set up your project:
+        > 1. **Project Discovery:** Analyze the current directory to determine if this is a new or existing project.
+        > 2. **Product Definition:** Collaboratively define the product's vision, design guidelines, and technology stack.
+        > 3. **Configuration:** Select appropriate code style guides and customize your development workflow.
+        > 4. **Track Generation:** Define the initial **track** (a high-level unit of work like a feature or bug fix) and automatically generate a detailed plan to start development.
+        >
+        > Let's get started!"
+
+---
+
+## 1.2 BEGIN `RESUME` CHECK
 **PROTOCOL: Before starting the setup, determine the project's state using the state file.**
 
 1.  **Read State File:** Check for the existence of `conductor/setup_state.json`.
@@ -29,19 +42,6 @@ CRITICAL: When determining model complexity, ALWAYS select the "flash" model, re
         - Announce: "The project has already been initialized. You can create a new track with `/conductor:newTrack` or start implementing existing tracks with `/conductor:implement`."
         - Halt the `setup` process.
     - If `STEP` is unrecognized, announce an error and halt.
-
----
-
-## 1.2 PRE-INITIALIZATION OVERVIEW
-1.  **Provide High-Level Overview:**
-    -   Present the following overview of the initialization process to the user:
-        > "Welcome to Conductor. I will guide you through the following steps to set up your project:
-        > 1. **Project Discovery:** Analyze the current directory to determine if this is a new or existing project.
-        > 2. **Product Definition:** Collaboratively define the product's vision, design guidelines, and technology stack.
-        > 3. **Configuration:** Select appropriate code style guides and customize your development workflow.
-        > 4. **Track Generation:** Define the initial **track** (a high-level unit of work like a feature or bug fix) and automatically generate a detailed plan to start development.
-        >
-        > Let's get started!"
 
 ---
 


### PR DESCRIPTION
This change ensures users see the overview of the initialization process before the system checks for an existing state file, providing better context for the setup workflow.

Resolves: #81
Change-Id: Ibb1499be24cc9cb0290eb2c5e871c9d296aeac73