### PR TITLE
feat(conductor): update review process to commit fixes and update plan

### DIFF
--- a/commands/conductor/review.toml
+++ b/commands/conductor/review.toml
@@ -114,48 +114,85 @@ CRITICAL: You must validate the success of every tool call. If any tool call fai
 ---
 
 ## 3.0 COMPLETION PHASE
-1.  **Review Decision:**
-    -   **Determine Recommendation and announce it to the user:**
-        -   If **Critical** or **High** issues found:
-            > "I recommend we fix the important issues I found before moving forward."
-        -   If only **Medium/Low** issues found:
-            > "The changes look good overall, but I have a few suggestions to improve them."
-        -   If no issues found:
-            > "Everything looks great! I don't see any issues."
-    -   **Action:**
-        -   **If issues found:** Ask:
-            > "Do you want me to apply the suggested fixes, fix them manually yourself, or proceed to complete the track?
-            > A. **Apply Fixes:** Automatically apply the suggested code changes.
-            > B. **Manual Fix:** Stop so you can fix issues yourself.
-            > C. **Complete Track:** Ignore warnings and proceed to cleanup.
-            > Please enter your choice (A, B, or C)."
-            -   **If "A" (Apply Fixes):** Apply the code modifications suggested in the findings using file editing tools. Then Proceed to next step.
-            -   **If "B" (Manual Fix):** Terminate operation to allow user to edit code.
-            -   **If "C" (Complete Track):** Proceed to the next step.
-        -   **If no issues found:** Proceed to the next step.
 
-2.  **Track Cleanup:**
-    **PROTOCOL: Offer to archive or delete the reviewed track.**
-
-    a.  **Context Check:** If you are NOT reviewing a specific track (e.g., just reviewing current changes without a track context), SKIP this entire section.
-
-    b.  **Ask for User Choice:**
-        > "Review complete. What would you like to do with track '<track_name>'?
-        > A.  **Archive:** Move to `conductor/archive/` and update registry.
-        > B.  **Delete:** Permanently remove from system.
-        > C.  **Skip:** Leave as is.
+### 3.1 Review Decision
+1.  **Determine Recommendation and announce it to the user:**
+    -   If **Critical** or **High** issues found:
+        > "I recommend we fix the important issues I found before moving forward."
+    -   If only **Medium/Low** issues found:
+        > "The changes look good overall, but I have a few suggestions to improve them."
+    -   If no issues found:
+        > "Everything looks great! I don't see any issues."
+2.  **Action:**
+    -   **If issues found:** Ask:
+        > "Do you want me to apply the suggested fixes, fix them manually yourself, or proceed to complete the track?
+        > A. **Apply Fixes:** Automatically apply the suggested code changes.
+        > B. **Manual Fix:** Stop so you can fix issues yourself.
+        > C. **Complete Track:** Ignore warnings and proceed to cleanup.
         > Please enter your choice (A, B, or C)."
+        -   **If "A" (Apply Fixes):** Apply the code modifications suggested in the findings using file editing tools. Then Proceed to next step.
+        -   **If "B" (Manual Fix):** Terminate operation to allow user to edit code.
+        -   **If "C" (Complete Track):** Proceed to the next step.
+    -   **If no issues found:** Proceed to the next step.
 
-    c.  **Handle User Response:**
-        *   **If "A" (Archive):**
-            i.   **Setup:** Ensure `conductor/archive/` exists.
-            ii.  **Move:** Move track folder to `conductor/archive/<track_id>`.
-            iii. **Update Registry:** Remove track section from **Tracks Registry**.
-            iv.  **Commit:** Stage registry and archive. Commit: `chore(conductor): Archive track '<track_name>'`.
-            v.   **Announce:** "Track '<track_name>' archived."
-        *   **If "B" (Delete):**
-            i.   **Confirm:** "WARNING: Irreversible deletion. Proceed? (yes/no)"
-            ii.  **If yes:** Delete track folder, remove from **Tracks Registry**, commit (`chore(conductor): Delete track '<track_name>'`), announce success.
-            iii. **If no:** Cancel.
-        *   **If "C" (Skip):** Leave track as is.
+### 3.2 Commit Review Changes
+**PROTOCOL: Ensure all review-related changes are committed and tracked in the plan.**
+
+1.  **Check for Changes:** Use `git status --porcelain` to check for any uncommitted changes (staged or unstaged) in the repository.
+2.  **Condition for Action:**
+    -   If NO changes are detected, proceed to '3.3 Track Cleanup'.
+    -   If changes are detected:
+        a. **Check for Track Context:**
+            - If you are NOT reviewing a specific track (i.e., you don't have a `plan.md` in context), simply offer to commit the changes:
+                > "I've detected uncommitted changes. Should I commit them? (yes/no)"
+                - If 'yes', stage all changes and commit with `fix(conductor): Apply review suggestions <brief description of changes>`.
+                - Proceed to '3.3 Track Cleanup'.
+        b. **Handle Track-Specific Changes:**
+            i.   **Confirm with User:**
+                > "I've detected uncommitted changes from the review process. Should I commit these and update the track's plan? (yes/no)"
+            ii.  **If Yes:**
+                 - **Update Plan (Add Review Task):**
+                   - Read the track's `plan.md`.
+                   - Append a new phase (if it doesn't exist) and task to the end of the file.
+                   - **Format:**
+                     ```markdown
+                     ## Phase: Review Fixes
+                     - [~] Task: Apply review suggestions
+                     ```
+                 - **Commit Code:**
+                   - Stage all code changes related to the track (excluding `plan.md`).
+                   - Commit with message: `fix(conductor): Apply review suggestions for track '<track_name>'`.
+                 - **Record SHA:**
+                   - Get the short SHA (first 7 characters) of the commit.
+                   - Update the task in `plan.md` to: `- [x] Task: Apply review suggestions <sha>`.
+                 - **Commit Plan Update:**
+                   - Stage `plan.md`.
+                   - Commit with message: `conductor(plan): Mark task 'Apply review suggestions' as complete`.
+                 - **Announce Success:** "Review changes committed and tracked in the plan."
+            iii. **If No:** Skip the commit and plan update. Proceed to '3.3 Track Cleanup'.
+
+### 3.3 Track Cleanup
+**PROTOCOL: Offer to archive or delete the reviewed track.**
+
+1.  **Context Check:** If you are NOT reviewing a specific track (e.g., just reviewing current changes without a track context), SKIP this entire section.
+
+2.  **Ask for User Choice:**
+    > "Review complete. What would you like to do with track '<track_name>'?
+    > A.  **Archive:** Move to `conductor/archive/` and update registry.
+    > B.  **Delete:** Permanently remove from system.
+    > C.  **Skip:** Leave as is.
+    > Please enter your choice (A, B, or C)."
+
+3.  **Handle User Response:**
+    *   **If "A" (Archive):**
+        i.   **Setup:** Ensure `conductor/archive/` exists.
+        ii.  **Move:** Move track folder to `conductor/archive/<track_id>`.
+        iii. **Update Registry:** Remove track section from **Tracks Registry**.
+        iv.  **Commit:** Stage registry and archive. Commit: `chore(conductor): Archive track '<track_name>'`.
+        v.   **Announce:** "Track '<track_name>' archived."
+    *   **If "B" (Delete):**
+        i.   **Confirm:** "WARNING: Irreversible deletion. Proceed? (yes/no)"
+        ii.  **If yes:** Delete track folder, remove from **Tracks Registry**, commit (`chore(conductor): Delete track '<track_name>'`), announce success.
+        iii. **If no:** Cancel.
+    *   **If "C" (Skip):** Leave track as is.
 """


### PR DESCRIPTION
This change ensures users save changes made after the review command, and that the track's plan (if relevant) is updated accordingly.

Change-Id: Id1f84748d29877b8a5794bb4cd02abdbc753e11d