### PR TITLE
docs(workflow): add no-chaining rule for Windows compatibility

### DIFF
--- a/templates/workflow.md
+++ b/templates/workflow.md
@@ -8,6 +8,7 @@
 4. **High Code Coverage:** Aim for >80% code coverage for all modules
 5. **User Experience First:** Every decision should prioritize user experience
 6. **Non-Interactive & CI-Aware:** Prefer non-interactive commands. Use `CI=true` for watch-mode tools (tests, linters) to ensure single execution.
+7. **No Command Chaining:** Do NOT chain commands with `&&` (especially `git`). Execute them as separate tool calls.
 
 ## Task Workflow
 


### PR DESCRIPTION
Windows environments struggle with && chaining and Gemini CLI requires explicit confirmation for chained commands even in YOLO mode. This update ensures smoother execution on Windows.