### PR TITLE
feat: Add plugin.json to make extension a plugin

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,6 +5,6 @@
   "author": {
     "name": "Google"
   },
-  "repository": "https://github.com/palladius/conductor",
+  "repository": "https://github.com/gemini-cli-extensions/conductor",
   "license": "Apache 2.0"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "conductor",
+  "version": "0.4.1",
+  "description": "Conductor is a Gemini CLI extension that enables Context-Driven Development.",
+  "author": {
+    "name": "Google"
+  },
+  "repository": "https://github.com/palladius/conductor",
+  "license": "Apache 2.0"
+}


### PR DESCRIPTION
This PR adds a plugin.json file to the root of the repository to register it as an official Gemini CLI plugin, matching the format used in other extensions.