### PR TITLE
fix: split malformed curl instruction into a fenced code block

### DIFF
--- a/skills/conductor-new-track/SKILL.md
+++ b/skills/conductor-new-track/SKILL.md
@@ -123,7 +123,12 @@ Adhere to this sequence precisely.
         -   **1p (Official):** Present as a verified Conductor skill.
         -   **3p (Community):** Present as a third-party skill. You MUST warn the user: *"Attention: This is a third-party skill. It will be installed as a frozen version (commit <sha>) for your safety."*
     -   **User Approval:** Ask the user to select which recommended skills they would like to install using a **multiple-choice question**.
-    -   **Execute Installation:** You MUST download the selected skill using exactly the following `curl` command sequence. Do not modify the parameters or add flags: `bash mkdir -p .agents/skills/<skill_name> curl -sSL <URL>SKILL.md -o .agents/skills/<skill_name>/SKILL.md`
+    -   **Execute Installation:** You MUST download the selected skill using exactly the following `curl` command sequence. Do not modify the parameters or add flags:
+
+        ```bash
+        mkdir -p .agents/skills/<skill_name>
+        curl -sSL <URL>SKILL.md -o .agents/skills/<skill_name>/SKILL.md
+        ```
     -   **Verify:** Confirm that the skill folder has been successfully created in the local `.agents/skills/` directory.
     -   **If no missing skills found:** Skip this section.
 


### PR DESCRIPTION
> **Automated**: drive-by fix from [NLPM](https://github.com/xiaolai/nlpm), an NL artifact linter. Reviewed and reproduced before submission.

**Bug**: `skills/conductor-new-track/SKILL.md:126` collapses the install commands into a single inline-code span prefixed with the literal word "bash" instead of a fenced ```bash block.

**Evidence**: Running the instruction literally (`bash mkdir -p .agents/skills/<skill_name> curl -sSL <URL>SKILL.md -o ...`) fails: `/usr/bin/mkdir: cannot execute binary file` (exit 126), since bash treats `mkdir` as a script argument rather than a command.

**Fix**: Splits the commands into a fenced ```bash block with `mkdir` and `curl` on separate lines, matching the correctly-formatted version of the same instruction at `skills/conductor-setup/SKILL.md:182-187`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->